### PR TITLE
rectangular source type, disk source with xy offset

### DIFF
--- a/src/mcx_const.h
+++ b/src/mcx_const.h
@@ -34,5 +34,6 @@
 #define MCX_SRC_ZGAUSSIAN  11 // Gaussian zenith anglular distribution
 #define MCX_SRC_LINE       12 // a non-directional line source
 #define MCX_SRC_SLIT       13 // a collimated line source
+#define MCX_SRC_RECTANGULAR       14 // a rectangular source
 
 #endif

--- a/src/mcx_utils.c
+++ b/src/mcx_utils.c
@@ -56,7 +56,7 @@ const char *fullopt[]={"--help","--interactive","--input","--photon",
 const char outputtype[]={'x','f','e','j','t','\0'};
 const char debugflag[]={'R','\0'};
 const char *srctypeid[]={"pencil","isotropic","cone","gaussian","planar",
-    "pattern","fourier","arcsine","disk","fourierx","fourierx2d","zgaussian","line","slit",""};
+    "pattern","fourier","arcsine","disk","fourierx","fourierx2d","zgaussian","line","slit", "rectangular", ""};
 
 void mcx_initcfg(Config *cfg){
      cfg->medianum=0;

--- a/src/mcx_utils.h
+++ b/src/mcx_utils.h
@@ -114,7 +114,7 @@ typedef struct MCXConfig{
 	char autopilot;     /**<1 optimal setting for dedicated card, 2, for non dedicated card*/
 	char issaveseed;    /**<1 save the seed for a detected photon, 0 do not save*/
 	char srctype;       /**<0:pencil,1:isotropic,2:cone,3:gaussian,4:planar,5:pattern,\
-                                6:fourier,7:arcsine,8:disk,9:fourierx,10:fourierx2d,11:zgaussian,12:line,13:slit*/
+							6:fourier,7:arcsine,8:disk,9:fourierx,10:fourierx2d,11:zgaussian,12:line,13:slit, 14: rectangular*/
         char outputtype;    /**<'X' output is flux, 'F' output is fluence, 'E' energy deposit*/
 	char faststep;
         float minenergy;    /**<minimum energy to propagate photon*/
@@ -133,7 +133,7 @@ typedef struct MCXConfig{
 	float4 srcparam2;   /**<a quadruplet {x,y,z,w} for additional source parameters*/
         float* srcpattern;  /**<a string for the source form, options include "pencil","isotropic",\
 	                        "cone","gaussian","planar", "pattern","fourier","arcsine","disk",\
-				"fourierx","fourierx2d","zgaussian","line","slit"*/
+				"fourierx","fourierx2d","zgaussian","line","slit", "rectangular"*/
 	Replay replay;
 	void *seeddata;
         int replaydet;      /**<the detector id for which to replay the detected photons, start from 1*/

--- a/src/mcxlab.cpp
+++ b/src/mcxlab.cpp
@@ -317,7 +317,7 @@ void mcx_set_field(const mxArray *root,const mxArray *item,int idx, Config *cfg)
 	printf("mcx.session='%s';\n",cfg->session);
     }else if(strcmp(name,"srctype")==0){
         int len=mxGetNumberOfElements(item);
-        const char *srctypeid[]={"pencil","isotropic","cone","gaussian","planar","pattern","fourier","arcsine","disk","fourierx","fourierx2d","zgaussian","line","slit",""};
+        const char *srctypeid[]={"pencil","isotropic","cone","gaussian","planar","pattern","fourier","arcsine","disk","fourierx","fourierx2d","zgaussian","line","slit", "rectangular",""};
         char strtypestr[MAX_SESSION_LENGTH]={'\0'};
 
         if(!mxIsChar(item) || len==0)


### PR DESCRIPTION
There are two new features regarding source types compared to master:
1) When using disk as source, changing the srcparam2.x[y] allows to shift the disk accordingly (e.g. in the center)
2) An additional type "rectangular" has been added with srcparam1.x[y, z] marking the lower left corner of the rectangle and srcparam2.x[y, z] stating the height (width, depth) of the source.
![mcx_disk_and_rectangular_source](https://cloud.githubusercontent.com/assets/1629580/14432006/87763ae6-0008-11e6-8173-f2aff7580268.png)
