### PR TITLE
modify post-processing to support normalization of multi-pattern

### DIFF
--- a/example/multipattern/multipattern.json
+++ b/example/multipattern/multipattern.json
@@ -27,7 +27,7 @@
 		}
 	},
 	"Domain": {
-		"OriginType": 0,
+		"OriginType": 1,
 		"Media": [
 			{
 				"mua": 0,

--- a/mcxlab/examples/demo_photon_sharing.m
+++ b/mcxlab/examples/demo_photon_sharing.m
@@ -25,6 +25,7 @@ cfg.srctype='pattern';
 cfg.srcpattern=permute(reshape(mcximg,[6,3,size(mcximg,2)]),[2 1 3]);
 cfg.srcnum=3;
 cfg.srcpos=[0 0 0];
+cfg.issrcfrom0=1;
 cfg.srcdir=[0 0 1];
 cfg.srcparam1=[60 0 0 size(cfg.srcpattern,2)];
 cfg.srcparam2=[0 60 0 size(cfg.srcpattern,3)];

--- a/mcxlab/mcxlab.m
+++ b/mcxlab/mcxlab.m
@@ -276,11 +276,13 @@ end
 
 cfg=varargin{1};
 
-for i=1:length(varargout{1})
-    if(isfield(cfg(i),'srcnum') && cfg(i).srcnum>1)
-        dim=size(varargout{1}(i).data);
-        varargout{1}(i).data=reshape(varargout{1}(i).data,[cfg(i).srcnum, dim(1)/cfg(i).srcnum dim(2:end)]);
-        varargout{1}(i).data=permute(varargout{1}(i).data,[2:(length(dim)+1) 1]);
+if(~ischar(cfg))
+    for i=1:length(varargout{1})
+        if(isfield(cfg(i),'srcnum') && cfg(i).srcnum>1)
+            dim=size(varargout{1}(i).data);
+            varargout{1}(i).data=reshape(varargout{1}(i).data,[cfg(i).srcnum, dim(1)/cfg(i).srcnum dim(2:end)]);
+            varargout{1}(i).data=permute(varargout{1}(i).data,[2:(length(dim)+1) 1]);
+        end
     end
 end
 

--- a/src/mcx_core.cu
+++ b/src/mcx_core.cu
@@ -670,18 +670,20 @@ __device__ inline int launchnewphoton(MCXpos *p,MCXdir *v,MCXtime *f,float3* rv,
 					       p->w);
 		      }
 		      if(gcfg->srctype==MCX_SRC_PATTERN){ // need to prevent rx/ry=1 here
-		          if(gcfg->srcnum<=1)
+		          if(gcfg->srcnum<=1){
 			      p->w=srcpattern[(int)(ry*JUST_BELOW_ONE*gcfg->srcparam2.w)*(int)(gcfg->srcparam1.w)+(int)(rx*JUST_BELOW_ONE*gcfg->srcparam1.w)];
-			  else{
+			      ppath[3]=p->w;
+			  }else{
 		            for(int i=0;i<gcfg->srcnum;i++)
 			      ppath[i+3]=srcpattern[((int)(ry*JUST_BELOW_ONE*gcfg->srcparam2.w)*(int)(gcfg->srcparam1.w)+(int)(rx*JUST_BELOW_ONE*gcfg->srcparam1.w))*gcfg->srcnum+i];
 			    p->w=1.f;
                           }
 		      }else if(gcfg->srctype==MCX_SRC_PATTERN3D){
-		          if(gcfg->srcnum<=1)
+		          if(gcfg->srcnum<=1){
 		              p->w=srcpattern[(int)(rz*JUST_BELOW_ONE*gcfg->srcparam1.z)*(int)(gcfg->srcparam1.y)*(int)(gcfg->srcparam1.x)+
 		                              (int)(ry*JUST_BELOW_ONE*gcfg->srcparam1.y)*(int)(gcfg->srcparam1.x)+(int)(rx*JUST_BELOW_ONE*gcfg->srcparam1.x)];
-			  else{
+			      ppath[3]=p->w;
+			  }else{
 		            for(int i=0;i<gcfg->srcnum;i++)
 		              ppath[i+3]=srcpattern[((int)(rz*JUST_BELOW_ONE*gcfg->srcparam1.z)*(int)(gcfg->srcparam1.y)*(int)(gcfg->srcparam1.x)+
 		                              (int)(ry*JUST_BELOW_ONE*gcfg->srcparam1.y)*(int)(gcfg->srcparam1.x)+(int)(rx*JUST_BELOW_ONE*gcfg->srcparam1.x))*gcfg->srcnum+i];
@@ -1497,6 +1499,7 @@ void mcx_run_simulation(Config *cfg,GPUInfo *gpu){
      float4 *Ppos,*Pdir,*Plen,*Plen0;
      uint   *Pseed;
      float  *Pdet;
+     float  *srcpw=NULL,*energytot=NULL,*energyabs=NULL; // for multi-srcpattern
      RandType *seeddata=NULL;
      uint    detected=0,sharedbuf=0;
 
@@ -1639,7 +1642,6 @@ void mcx_run_simulation(Config *cfg,GPUInfo *gpu){
          fieldlen=dimxyz*gpu[gpuid].maxgate*cfg->detnum;
      else
          fieldlen=dimxyz*gpu[gpuid].maxgate;
-
      mcgrid.x=gpu[gpuid].autothread/gpu[gpuid].autoblock;
      mcblock.x=gpu[gpuid].autoblock;
 
@@ -2043,46 +2045,88 @@ is more than what your have specified (%d), please use the -H option to specify 
      /*let the master thread to deal with the normalization and file IO*/
 #pragma omp master
 {
+     if(cfg->srctype==MCX_SRC_PATTERN && cfg->srcnum>1){// post-processing only for multi-srcpattern
+         srcpw=(float *)calloc(cfg->srcnum,sizeof(float));
+	 energytot=(float *)calloc(cfg->srcnum,sizeof(float));
+	 energyabs=(float *)calloc(cfg->srcnum,sizeof(float));
+	 int psize=(int)cfg->srcparam1.w*(int)cfg->srcparam2.w;
+	 for(i=0;i<int(cfg->srcnum);i++){
+	     for(iter=0;iter<psize;iter++)   
+	         srcpw[i]+=cfg->srcpattern[iter*cfg->srcnum+i];
+	     energytot[i]=cfg->energytot*srcpw[i]/(float)psize;
+	     float kahanc=0.f,kahany,kahant;
+	     if(cfg->outputtype==otEnergy){
+	         int fieldlenPsrc=fieldlen/cfg->srcnum;
+	         for(iter=0;iter<fieldlenPsrc;iter++){
+		     kahany=cfg->exportfield[iter*cfg->srcnum+i]-kahanc;
+		     kahant=energyabs[i]+kahany;
+		     kahanc=(kahant-energyabs[i])-kahany;
+		     energyabs[i]=kahant;
+		 }
+	     }else{
+	         int j;
+	         for(iter=0;iter<gpu[gpuid].maxgate;iter++){
+		     for(j=0;j<(int)dimlen.z;j++){
+		         kahany=cfg->exportfield[iter*dimxyz+(j*cfg->srcnum+i)]*cfg->prop[cfg->vol[j]].mua-kahanc;
+		         kahant=energyabs[i]+kahany;
+		         kahanc=(kahant-energyabs[i])-kahany;
+		         energyabs[i]=kahant;
+		     }
+		 }
+	     }
+	 }
+     }
      if(cfg->isnormalized){
-	   float scale=1.f;
+	   float *scale=(float *)calloc(cfg->srcnum,sizeof(float));
+	   scale[0]=1.f;
 	   int isnormalized=0;
            MCX_FPRINTF(cfg->flog,"normalizing raw data ...\t");
            cfg->energyabs+=cfg->energytot-cfg->energyesc;
            if(cfg->outputtype==otFlux || cfg->outputtype==otFluence){
-               scale=cfg->unitinmm/(cfg->energytot*Vvox*cfg->tstep); /* Vvox (in mm^3 already) * (Tstep) * (Eabsorp/U) */
+               scale[0]=cfg->unitinmm/(cfg->energytot*Vvox*cfg->tstep); /* Vvox (in mm^3 already) * (Tstep) * (Eabsorp/U) */
 
                if(cfg->outputtype==otFluence)
-		   scale*=cfg->tstep;
+		   scale[0]*=cfg->tstep;
 	   }else if(cfg->outputtype==otEnergy)
-	       scale=1.f/cfg->energytot;
+	       scale[0]=1.f/cfg->energytot;
 	   else if(cfg->outputtype==otJacobian || cfg->outputtype==otWP || cfg->outputtype==otDCS){
 	       if(cfg->seed==SEED_FROM_FILE && cfg->replaydet==-1){
                    int detid;
 		   for(detid=1;detid<=(int)cfg->detnum;detid++){
-	               scale=0.f; // the cfg->normalizer and cfg.his.normalizer are inaccurate in this case, but this is ok
+	               scale[0]=0.f; // the cfg->normalizer and cfg.his.normalizer are inaccurate in this case, but this is ok
 		       for(size_t i=0;i<cfg->nphoton;i++)
 		           if(cfg->replay.detid[i]==detid)
-	                       scale+=cfg->replay.weight[i];
-	               if(scale>0.f)
-	                   scale=cfg->unitinmm/scale;
-                       MCX_FPRINTF(cfg->flog,"normalization factor for detector %d alpha=%f\n",detid, scale);  fflush(cfg->flog);
-                       mcx_normalize(cfg->exportfield+(detid-1)*dimxyz*gpu[gpuid].maxgate,scale,dimxyz*gpu[gpuid].maxgate,cfg->isnormalized);
+	                       scale[0]+=cfg->replay.weight[i];
+	               if(scale[0]>0.f)
+	                   scale[0]=cfg->unitinmm/scale[0];
+                       MCX_FPRINTF(cfg->flog,"normalization factor for detector %d alpha=%f\n",detid, scale[0]);  fflush(cfg->flog);
+                       mcx_normalize(cfg->exportfield+(detid-1)*dimxyz*gpu[gpuid].maxgate,scale[0],dimxyz*gpu[gpuid].maxgate,cfg->isnormalized,0,1);
 		   }
 		   isnormalized=1;
 	       }else{
-	           scale=0.f;
+	           scale[0]=0.f;
 	           for(size_t i=0;i<cfg->nphoton;i++)
-	               scale+=cfg->replay.weight[i];
-	           if(scale>0.f)
-                       scale=cfg->unitinmm/scale;
+	               scale[0]+=cfg->replay.weight[i];
+	           if(scale[0]>0.f)
+                       scale[0]=cfg->unitinmm/scale[0];
 	       }
            }
-         cfg->normalizer=scale;
-	 cfg->his.normalizer=scale;
+	   if(cfg->srctype==MCX_SRC_PATTERN && cfg->srcnum>1){// post-processing only for multi-srcpattern
+	       float scaleref=scale[0];
+	       int psize=(int)cfg->srcparam1.w*(int)cfg->srcparam2.w;
+	       for(i=0;i<int(cfg->srcnum);i++){
+		   scale[i]=psize/srcpw[i]*scaleref;
+	       }
+	   }
+         cfg->normalizer=scale[0];
+	 cfg->his.normalizer=scale[0];
          if(!isnormalized){
-             MCX_FPRINTF(cfg->flog,"normalization factor alpha=%f\n",scale);  fflush(cfg->flog);
-	     mcx_normalize(cfg->exportfield,scale,fieldlen,cfg->isnormalized);
+	     for(i=0;i<(int)cfg->srcnum;i++){
+                 MCX_FPRINTF(cfg->flog,"source %d, normalization factor alpha=%f\n",(i+1),scale[i]);  fflush(cfg->flog);
+	         mcx_normalize(cfg->exportfield,scale[i],fieldlen/cfg->srcnum,cfg->isnormalized,i,cfg->srcnum);
+	     }
 	 }
+	 free(scale);
      }
      if(cfg->issave2pt && cfg->parentid==mpStandalone){
          MCX_FPRINTF(cfg->flog,"saving data to file ... %lu %d\t",fieldlen,gpu[gpuid].maxgate);
@@ -2131,9 +2175,16 @@ is more than what your have specified (%d), please use the -H option to specify 
      MCX_FPRINTF(cfg->flog,"simulated %ld photons (%ld) with %d threads (repeat x%d)\nMCX simulation speed: %.2f photon/ms\n",
              (long int)cfg->nphoton*((cfg->respin>1) ? (cfg->respin) : 1),(long int)cfg->nphoton*((cfg->respin>1) ? (cfg->respin) : 1),
 	     gpu[gpuid].autothread,ABS(cfg->respin),(double)cfg->nphoton*((cfg->respin>1) ? (cfg->respin) : 1)/max(1,cfg->runtime)); fflush(cfg->flog);
-     MCX_FPRINTF(cfg->flog,"total simulated energy: %.2f\tabsorbed: %5.5f%%\n(loss due to initial specular reflection is excluded in the total)\n",
+     if(cfg->srctype==MCX_SRC_PATTERN && cfg->srcnum>1){
+         for(i=0;i<(int)cfg->srcnum;i++){
+	     MCX_FPRINTF(cfg->flog,"source #%d total simulated energy: %.2f\tabsorbed: %5.5f%%\n(loss due to initial specular reflection is excluded in the total)\n",
+                 i+1,energytot[i],energyabs[i]/energytot[i]*100.f);fflush(cfg->flog);
+	 }
+     }else{
+         MCX_FPRINTF(cfg->flog,"total simulated energy: %.2f\tabsorbed: %5.5f%%\n(loss due to initial specular reflection is excluded in the total)\n",
              cfg->energytot,(cfg->energytot-cfg->energyesc)/cfg->energytot*100.f);fflush(cfg->flog);
-     fflush(cfg->flog);
+         fflush(cfg->flog);
+     }
      
      cfg->energyabs=cfg->energytot-cfg->energyesc;
 }
@@ -2171,4 +2222,7 @@ is more than what your have specified (%d), please use the -H option to specify 
      free(Pdet);
      free(energy);
      free(field);
+     free(srcpw);
+     free(energytot);
+     free(energyabs);
 }

--- a/src/mcx_core.cu
+++ b/src/mcx_core.cu
@@ -2051,28 +2051,20 @@ is more than what your have specified (%d), please use the -H option to specify 
 	 energyabs=(float *)calloc(cfg->srcnum,sizeof(float));
 	 int psize=(int)cfg->srcparam1.w*(int)cfg->srcparam2.w;
 	 for(i=0;i<int(cfg->srcnum);i++){
+	     float kahanc=0.f;
 	     for(iter=0;iter<psize;iter++)   
-	         srcpw[i]+=cfg->srcpattern[iter*cfg->srcnum+i];
+	         mcx_kahanSum(&srcpw[i],&kahanc,cfg->srcpattern[iter*cfg->srcnum+i]);
 	     energytot[i]=cfg->energytot*srcpw[i]/(float)psize;
-	     float kahanc=0.f,kahany,kahant;
+	     kahanc=0.f;
 	     if(cfg->outputtype==otEnergy){
 	         int fieldlenPsrc=fieldlen/cfg->srcnum;
-	         for(iter=0;iter<fieldlenPsrc;iter++){
-		     kahany=cfg->exportfield[iter*cfg->srcnum+i]-kahanc;
-		     kahant=energyabs[i]+kahany;
-		     kahanc=(kahant-energyabs[i])-kahany;
-		     energyabs[i]=kahant;
-		 }
+	         for(iter=0;iter<fieldlenPsrc;iter++)
+		     mcx_kahanSum(&energyabs[i],&kahanc,cfg->exportfield[iter*cfg->srcnum+i]);
 	     }else{
 	         int j;
-	         for(iter=0;iter<gpu[gpuid].maxgate;iter++){
-		     for(j=0;j<(int)dimlen.z;j++){
-		         kahany=cfg->exportfield[iter*dimxyz+(j*cfg->srcnum+i)]*cfg->prop[cfg->vol[j]].mua-kahanc;
-		         kahant=energyabs[i]+kahany;
-		         kahanc=(kahant-energyabs[i])-kahany;
-		         energyabs[i]=kahant;
-		     }
-		 }
+	         for(iter=0;iter<gpu[gpuid].maxgate;iter++)
+		     for(j=0;j<(int)dimlen.z;j++)
+		         mcx_kahanSum(&energyabs[i],&kahanc,cfg->exportfield[iter*dimxyz+(j*cfg->srcnum+i)]*cfg->prop[cfg->vol[j]].mua);
 	     }
 	 }
      }

--- a/src/mcx_utils.c
+++ b/src/mcx_utils.c
@@ -496,6 +496,22 @@ void mcx_normalize(float field[], float scale, int fieldlen, int option, int pid
 }
 
 /**
+ * @brief Kahan summation: Add a sequence of finite precision floating point numbers  
+ *
+ * Source: https://en.wikipedia.org/wiki/Kahan_summation_algorithm
+ * @param[in,out] sum: sum of the squence before and after adding the next element
+ * @param[in,out] kahanc: a running compensation for lost low-order bits
+ * @param[in] input: the next element of the sequence
+ */
+ 
+ void mcx_kahanSum(float *sum, float *kahanc, float input){
+     float kahany=input-*kahanc;
+     float kahant=*sum+kahany;
+     *kahanc=kahant-*sum-kahany;
+     *sum=kahant;
+ }
+
+/**
  * @brief Force flush the command line to print the message
  *
  * @param[in] cfg: simulation configuration

--- a/src/mcx_utils.c
+++ b/src/mcx_utils.c
@@ -486,12 +486,12 @@ void mcx_printlog(Config *cfg, char *str){
  * @param[in] option: if set to 2, only normalize positive values (negative values for diffuse reflectance calculations)
  */
 
-void mcx_normalize(float field[], float scale, int fieldlen, int option){
+void mcx_normalize(float field[], float scale, int fieldlen, int option, int pidx, int srcnum){
      int i;
      for(i=0;i<fieldlen;i++){
-         if(option==2 && field[i]<0.f)
+         if(option==2 && field[i*srcnum+pidx]<0.f)
 	     continue;
-         field[i]*=scale;
+         field[i*srcnum+pidx]*=scale;
      }
 }
 

--- a/src/mcx_utils.h
+++ b/src/mcx_utils.h
@@ -232,6 +232,7 @@ void mcx_usage(Config *cfg,char *exename);
 void mcx_printheader(Config *cfg);
 void mcx_loadvolume(char *filename,Config *cfg);
 void mcx_normalize(float field[], float scale, int fieldlen, int option, int pidx, int srcnum);
+void mcx_kahanSum(float *sum, float *kahanc, float input);
 int  mcx_readarg(int argc, char *argv[], int id, void *output,const char *type);
 void mcx_printlog(Config *cfg, char *str);
 int  mcx_remap(char *opt);

--- a/src/mcx_utils.h
+++ b/src/mcx_utils.h
@@ -231,7 +231,7 @@ void mcx_parsecmd(int argc, char* argv[], Config *cfg);
 void mcx_usage(Config *cfg,char *exename);
 void mcx_printheader(Config *cfg);
 void mcx_loadvolume(char *filename,Config *cfg);
-void mcx_normalize(float field[], float scale, int fieldlen, int option);
+void mcx_normalize(float field[], float scale, int fieldlen, int option, int pidx, int srcnum);
 int  mcx_readarg(int argc, char *argv[], int id, void *output,const char *type);
 void mcx_printlog(Config *cfg, char *str);
 int  mcx_remap(char *opt);


### PR DESCRIPTION
1. implement normalization for multi-pattern and update the corresponding command window printing
2. for multi-pattern, add mcx_kahanSum function to accumulate a sequence of finite precision floating point numbers
3. update the photon sharing demo: issrcfrom0 should be set to 1 for multi-pattern
4. fix incorrect output field for one source pattern
5. fix mcxlab 'gpuinfo' output error when there are multiple GPUs