### PR TITLE
fix indexing mismatch between mcx_replay_prep and mcx detphotons output

### DIFF
--- a/src/mcxlab.cpp
+++ b/src/mcxlab.cpp
@@ -715,9 +715,9 @@ void mcx_replay_prep(Config *cfg){
             cfg->replay.weight[cfg->nphoton]=1.f;
 	    cfg->replay.tof[cfg->nphoton]=0.f;
             cfg->replay.detid[cfg->nphoton]=(int)(detps[i*dimdetps[0]]);
-            for(j=2;j<cfg->medianum+1;j++){
-                cfg->replay.weight[cfg->nphoton]*=expf(-cfg->prop[j-1].mua*detps[i*dimdetps[0]+j]*cfg->unitinmm);
-                cfg->replay.tof[cfg->nphoton]+=detps[i*dimdetps[0]+j]*cfg->unitinmm*R_C0*cfg->prop[j-1].n;
+            for(j=0;j<cfg->medianum-1;j++){
+                cfg->replay.weight[cfg->nphoton]*=expf(-cfg->prop[j+1].mua*detps[i*dimdetps[0]+cfg->medianum+j]*cfg->unitinmm);
+                cfg->replay.tof[cfg->nphoton]+=detps[i*dimdetps[0]+cfg->medianum+j]*cfg->unitinmm*R_C0*cfg->prop[j+1].n;
             }
             if(cfg->replay.tof[cfg->nphoton]<cfg->tstart || cfg->replay.tof[cfg->nphoton]>cfg->tend) /*need to consider -g*/
                 continue;


### PR DESCRIPTION
https://github.com/fangq/mcx/commit/7e45ec04de9575e405411ae3d01c7c0b2ef0df3a In this commit, MCX is updated to produce detected photon output matches that of MMC, in particular, instead of reporting nscat for all tissue types, MCX reports nscat for each tissue type respectively, but the corresponding part in mcx_replay_prep is not updated and this draws an error in demo_replay_vs_pmc_timedomain.m when the background media are heterogeneous.