### PR TITLE
fix print information for multiptle patterns when cfg.isnormalized==0

### DIFF
--- a/src/mcx_core.cu
+++ b/src/mcx_core.cu
@@ -2114,7 +2114,7 @@ is more than what your have specified (%d), please use the -H option to specify 
 	     float kahanc=0.f;
 	     for(iter=0;iter<psize;iter++)   
 	         mcx_kahanSum(&srcpw[i],&kahanc,cfg->srcpattern[iter*cfg->srcnum+i]);
-	     energytot[i]=cfg->energytot*srcpw[i]/(float)psize;
+	     energytot[i]=cfg->nphoton*srcpw[i]/(float)psize;
 	     kahanc=0.f;
 	     if(cfg->outputtype==otEnergy){
 	         int fieldlenPsrc=fieldlen/cfg->srcnum;


### PR DESCRIPTION
Currently, [cfg->energytot is NOT returned to host when cfg->isnormalized is 0](https://github.com/fangq/mcx/blob/43b377a722bc3c0c9ce8aa2ee1ab0c3977725c5f/src/mcx_core.cu#L2079-L2089). As a result, energytot, which will be used in [print](https://github.com/fangq/mcx/blob/43b377a722bc3c0c9ce8aa2ee1ab0c3977725c5f/src/mcx_core.cu#L2230-L2234), can not be evaluated properly for multiple patterns.
Meanwhile, for photon sharing, cfg->energytot==cfg->nphoton is always true when cfg->srcnum>1. Therefore here we replace cfg->energytot using cfg->nphoton to solve the above issue.
