### PR TITLE
consider unitinmm in "mcxmeanpath.m"

### DIFF
--- a/utils/mcxmeanpath.m
+++ b/utils/mcxmeanpath.m
@@ -17,6 +17,11 @@ function avgpath=mcxmeanpath(detp,prop)
 %
 % License: GPLv3, see http://mcx.space/ for details
 %
+ if(isfield(detp,'unitinmm'))
+    unitinmm=detp.unitinmm;
+else
+    unitinmm=1;
+end
 
 detw=mcxdetweight(detp,prop);
-avgpath=sum(detp.ppath.*repmat(detw(:),1,size(detp.ppath,2))) / sum(detw(:));
+avgpath=sum(detp.ppath.*unitinmm.*repmat(detw(:),1,size(detp.ppath,2))) / sum(detw(:));


### PR DESCRIPTION
Hi Dr. Fang,

I think the mcxmeanpath.m function also needed to be modified, besides mcxdetweight.m. When I calculated the mean pathlength, I had to multiply detp.ppath by unitinmm before I throw them into the function mcxmeanpath. Now the mcxdetweight.m takes unitinmm into consideration, should I change the mcxmeanpath.m function like below? I modified the code and the result looks correct.