### PR TITLE
Update mcxpreview

### DIFF
--- a/mcxlab/mcxpreview.m
+++ b/mcxlab/mcxpreview.m
@@ -135,7 +135,7 @@ for i=1:len
                 vec2=cfg(i).srcparam2(1:3)*voxelsize;
             end
             nrec=[0 0 0; cfg(i).srcparam1(1:3)*voxelsize; cfg(i).srcparam1(1:3)*voxelsize+vec2; vec2];
-            hsrcarea=plotmesh(rotatevec3d(nrec,[0 0 1], cfg(i).srcdir, srcpos), {[1 2 3 4 1]});
+            hsrcarea=plotmesh(rotatevec3d(nrec, cfg(i).srcdir, cfg(i).srcdir, srcpos), {[1 2 3 4 1]});
         elseif(strcmp(cfg(i).srctype,'pattern3d'))
             dim=cfg(i).srcparam1(1:3);
             [bbxno,bbxfc]=latticegrid(0:dim(1):dim(1),0:dim(2):dim(2),0:dim(3):dim(3));

--- a/src/mcx_const.h
+++ b/src/mcx_const.h
@@ -75,6 +75,7 @@
 #define MCX_SRC_SLIT       13 /**<  a collimated line source */
 #define MCX_SRC_PENCILARRAY 14 /**<  a rectangular array of pencil beams */
 #define MCX_SRC_PATTERN3D  15  /**<  a 3D pattern source, starting from srcpos, srcparam1.{x,y,z} define the x/y/z dimensions */
+#define MCX_SRC_ANGLEPATTERN 16  /**<  a pattern which is the CDF of the total energy of the certain angle */
 
 #define SAVE_DETID(a)         ((a)    & 0x1)   /**<  mask to save detector ID*/
 #define SAVE_NSCAT(a)         ((a)>>1 & 0x1)   /**<  output partial scattering counts */

--- a/src/mcx_core.cu
+++ b/src/mcx_core.cu
@@ -2043,6 +2043,8 @@ void mcx_run_simulation(Config *cfg,GPUInfo *gpu){
            CUDA_ASSERT(cudaMemcpy(gsrcpattern,cfg->srcpattern,sizeof(float)*(int)(cfg->srcparam1.w*cfg->srcparam2.w*cfg->srcnum), cudaMemcpyHostToDevice));
 	else if(cfg->srctype==MCX_SRC_PATTERN3D)
 	   CUDA_ASSERT(cudaMemcpy(gsrcpattern,cfg->srcpattern,sizeof(float)*(int)(cfg->srcparam1.x*cfg->srcparam1.y*cfg->srcparam1.z*cfg->srcnum), cudaMemcpyHostToDevice));
+        else if(cfg->srctype==MCX_SRC_ANGLEPATTERN)
+           CUDA_ASSERT(cudaMemcpy(gsrcpattern,cfg->srcpattern,sizeof(float)*(int)(cfg->srcparam1.x*2), cudaMemcpyHostToDevice));
      
 
      CUDA_ASSERT(cudaMemcpyToSymbol(gproperty, cfg->prop,  cfg->medianum*sizeof(Medium), 0, cudaMemcpyHostToDevice));

--- a/src/mcxlab.cpp
+++ b/src/mcxlab.cpp
@@ -629,7 +629,7 @@ void mcx_set_field(const mxArray *root,const mxArray *item,int idx, Config *cfg)
         int len=mxGetNumberOfElements(item);
         const char *srctypeid[]={"pencil","isotropic","cone","gaussian","planar",
 	   "pattern","fourier","arcsine","disk","fourierx","fourierx2d","zgaussian",
-	   "line","slit","pencilarray","pattern3d",""};
+	   "line","slit","pencilarray","pattern3d","anglepattern",""};
         char strtypestr[MAX_SESSION_LENGTH]={'\0'};
 
         if(!mxIsChar(item) || len==0)
@@ -898,7 +898,7 @@ void mcx_validate_config(Config *cfg){
         mexErrMsgTxt("you must define the 'prop' field in the input structure");
      if(cfg->dim.x==0||cfg->dim.y==0||cfg->dim.z==0)
         mexErrMsgTxt("the 'vol' field in the input structure can not be empty");
-     if((cfg->srctype==MCX_SRC_PATTERN || cfg->srctype==MCX_SRC_PATTERN3D) && cfg->srcpattern==NULL)
+     if((cfg->srctype==MCX_SRC_PATTERN || cfg->srctype==MCX_SRC_PATTERN3D || cfg->srctype==MCX_SRC_ANGLEPATTERN) && cfg->srcpattern==NULL)
         mexErrMsgTxt("the 'srcpattern' field can not be empty when your 'srctype' is 'pattern'");
      if(cfg->steps.x!=1.f && cfg->unitinmm==1.f)
         cfg->unitinmm=cfg->steps.x;


### PR DESCRIPTION
Not rotate the quadrilateral by srcdir while using planar or pattern source type.

For example, in the `demo_photon_sharing.m`, if I set the srcparam1 and srcparam2 like that, the preview will be not consistent with the setting.
![image](https://user-images.githubusercontent.com/26135032/82981457-b2f3b300-a01e-11ea-9a7a-7319a525a51d.png)
But the simulation result will be consistent with the setting.
![image](https://user-images.githubusercontent.com/26135032/82981618-0d8d0f00-a01f-11ea-9e75-4a1ea0f93f05.png)

After change a little bit in `mcxpreview.m`, the preview will be consistent with the setting.
![image](https://user-images.githubusercontent.com/26135032/82981674-2ac1dd80-a01f-11ea-8a02-2ca23fbf38e7.png)

