### PR TITLE
fix preview for pattern source etc.

### DIFF
--- a/mcxlab/mcxpreview.m
+++ b/mcxlab/mcxpreview.m
@@ -135,7 +135,7 @@ for i=1:len
                 vec2=cfg(i).srcparam2(1:3)*voxelsize;
             end
             nrec=[0 0 0; cfg(i).srcparam1(1:3)*voxelsize; cfg(i).srcparam1(1:3)*voxelsize+vec2; vec2];
-            hsrcarea=plotmesh(rotatevec3d(nrec,[0 0 1], cfg(i).srcdir, srcpos), {[1 2 3 4 1]});
+            hsrcarea=plotmesh(nrec+repmat(srcpos(:)',[4,1]), {[1 2 3 4 1]});
         elseif(strcmp(cfg(i).srctype,'pattern3d'))
             dim=cfg(i).srcparam1(1:3);
             [bbxno,bbxfc]=latticegrid(0:dim(1):dim(1),0:dim(2):dim(2),0:dim(3):dim(3));


### PR DESCRIPTION
Fix the orientation of the source plane.
Not rotate the quadrilateral by srcdir while using planar or pattern source type.

For example, in the `demo_photon_sharing.m`, if I set the srcparam1 and srcparam2 like that, the preview will be not consistent with the setting.
![image](https://user-images.githubusercontent.com/26135032/82981457-b2f3b300-a01e-11ea-9a7a-7319a525a51d.png)
But the simulation result will be consistent with the setting.
![image](https://user-images.githubusercontent.com/26135032/82981618-0d8d0f00-a01f-11ea-9e75-4a1ea0f93f05.png)

After change a little bit in `mcxpreview.m`, the preview will be consistent with the setting.
![image](https://user-images.githubusercontent.com/26135032/82981674-2ac1dd80-a01f-11ea-8a02-2ca23fbf38e7.png)