### PR TITLE
fix fluence for mua -> 0

### DIFF
--- a/src/mcx_core.cu
+++ b/src/mcx_core.cu
@@ -1935,7 +1935,7 @@ __global__ void mcx_main_loop(uint media[], OutputType field[], float genergy[],
                 if (gcfg->outputtype == otEnergy) {
                     weight = w0 - p.w;
                 } else if (gcfg->outputtype == otFluence || gcfg->outputtype == otFlux) {
-                    weight = (prop.mua/prop.mus < 0.001) ? (w0 * len * (1 - prop.mua * len / 2)) : ((w0 - p.w) / (prop.mua));
+                    weight = (prop.mua * len < 0.001f) ? (w0 * len * (1.f - prop.mua * len * 0.5f)) : ((w0 - p.w) / (prop.mua));
                 } else if (gcfg->seed == SEED_FROM_FILE) {
                     if (gcfg->outputtype == otJacobian || gcfg->outputtype == otRF) {
                         weight = replayweight[(idx * gcfg->threadphoton + min(idx, gcfg->oddphotons - 1) + (int)f.ndone)] * f.pathlen;

--- a/src/mcx_core.cu
+++ b/src/mcx_core.cu
@@ -1935,7 +1935,7 @@ __global__ void mcx_main_loop(uint media[], OutputType field[], float genergy[],
                 if (gcfg->outputtype == otEnergy) {
                     weight = w0 - p.w;
                 } else if (gcfg->outputtype == otFluence || gcfg->outputtype == otFlux) {
-                    weight = (prop.mua == 0.f) ? 0.f : ((w0 - p.w) / (prop.mua));
+                    weight = (prop.mua/prop.mus < 0.001) ? (w0 * len * (1 - prop.mua * len / 2)) : ((w0 - p.w) / (prop.mua));
                 } else if (gcfg->seed == SEED_FROM_FILE) {
                     if (gcfg->outputtype == otJacobian || gcfg->outputtype == otRF) {
                         weight = replayweight[(idx * gcfg->threadphoton + min(idx, gcfg->oddphotons - 1) + (int)f.ndone)] * f.pathlen;


### PR DESCRIPTION
Dear Prof. Fang,

I was playing with MCXlab at low absorption values, but it seems that below a certain threshold the fluence fails numerically and becomes eventually zero. The threshold can be lowered by turning on the `DUSE_DOUBLE` and `DUSE_MORE_DOUBLE` flags, but in principle the correct limit for low absorption is simply obtained by accumulating the appropriate Taylor expansion for the exponential `w0 * (1 - exp(-prop.mua * len)) / prop.mua`.
To take advantage of this one can introduce an `if` condition depending on the `prop.mua / prop.mus` ratio instead of the currently implemented zero value for `prop.mua == 0`. See the picture below relative to a homogeneous medium.

![low mua limit](https://user-images.githubusercontent.com/90262595/225963260-2a4471aa-da59-4384-8a7a-d196e175c05a.png)

The dashed line value is calculated as the average pathlength in the medium (which is given by [line 1894 of mcx_core.cu](https://github.com/fangq/mcx/blob/1d9eaf18d069baa817b4c7ea83ec6b11105027b9/src/mcx_core.cu#L1894)). Strangely enough, a small difference is visible between when the `if` condition kicks in. A Kahan summation may be needed somewhere? Adding the same `if` condition and Taylor expansion at line 1894 returns instead a smooth convergence to the dashed value.

Perhaps this is not the ideal solution, but I think it could still be preferable compared to the drastic loss of precision at low mua and the incorrect fluence value that is currently set for null absorption.