### PR TITLE
use a new approach to wrap 8-byte volume for svmc

### DIFF
--- a/src/mcx_utils.c
+++ b/src/mcx_utils.c
@@ -1615,8 +1615,8 @@ void mcx_preprocess(Config* cfg) {
                 b2u.c[7] = val[(i << 3)]; // lower label and upper label
                 b2u.c[6] = val[(i << 3) + 1];
 
-                newvol[i] = b2u.i[1]; // first half: high 4 byte, second half: low 4 bytes
-                newvol[i + dimxyz] = b2u.i[0];
+                newvol[i * 2] = b2u.i[1]; // first half: high 4 byte, second half: low 4 bytes
+                newvol[i * 2 + 1] = b2u.i[0];
             }
 
             memcpy(cfg->vol, newvol, (dimxyz << 3));


### PR DESCRIPTION
Performance comparison:
1. demo_svmc_brain19_5.m: **3503** photon/ms -> **3593** photon/ms
2. demo_svmc_cubesph.m: **36900** photon/ms -> **36536** photon/ms
3. demo_svmc_sphshells.m: **6707** photon/ms -> **6841** photon/ms