### PR TITLE
add user customized angle pattern (input invCDF)

### DIFF
--- a/schema/mcxinput.json
+++ b/schema/mcxinput.json
@@ -218,7 +218,8 @@
                 "slit",
                 "pencilarray",
                 "hyperboloid",
-                "ring"
+                "ring",
+                "anglepattern"
               ]
             },
             "Pos": {

--- a/src/mcx_const.h
+++ b/src/mcx_const.h
@@ -94,6 +94,7 @@
 #define MCX_SRC_PATTERN3D  15  /**<  a 3D pattern source, starting from srcpos, srcparam1.{x,y,z} define the x/y/z dimensions */
 #define MCX_SRC_HYPERBOLOID_GAUSSIAN 16 /**<  Gaussian-beam with spot focus, scrparam1.{x,y,z} define beam waist, distance from source to focus, rayleigh range */
 #define MCX_SRC_RING       17 /**<  ring/ring-sector source, scrparam1.{x,y} defines the outer/inner radius, srcparam1.{z,w} defines start/end angle*/
+#define MCX_SRC_ANGLEPATTERN 18 /**< a pattern which is the CDF of the total energy of the certain angle */
 
 #define SAVE_DETID(a)         ((a)    & 0x1)   /**<  mask to save detector ID*/
 #define SAVE_NSCAT(a)         ((a)>>1 & 0x1)   /**<  output partial scattering counts */

--- a/src/mcx_utils.c
+++ b/src/mcx_utils.c
@@ -201,7 +201,7 @@ const char boundarydetflag[] = {'0', '1', '\0'};
 
 const char* srctypeid[] = {"pencil", "isotropic", "cone", "gaussian", "planar",
                            "pattern", "fourier", "arcsine", "disk", "fourierx", "fourierx2d", "zgaussian",
-                           "line", "slit", "pencilarray", "pattern3d", "hyperboloid", "ring", ""
+                           "line", "slit", "pencilarray", "pattern3d", "hyperboloid", "ring", "anglepattern", ""
                           };
 
 

--- a/src/mcx_utils.h
+++ b/src/mcx_utils.h
@@ -212,7 +212,7 @@ typedef struct MCXConfig {
     int  zipid;                  /**<data zip method "zlib","gzip","base64","lzip","lzma","lz4","lz4hc"*/
     char srctype;                /**<0:pencil,1:isotropic,2:cone,3:gaussian,4:planar,5:pattern,\
                                          6:fourier,7:arcsine,8:disk,9:fourierx,10:fourierx2d,11:zgaussian,\
-                                         12:line,13:slit,14:pencilarray,15:pattern3d,16:hyperboloid,17:ring*/
+                                         12:line,13:slit,14:pencilarray,15:pattern3d,16:hyperboloid,17:ring,18:anglepattern*/
     char outputtype;             /**<'X' output is flux, 'F' output is fluence, 'E' energy deposit*/
     char outputformat;           /**<'mc2' output is text, 'nii': binary, 'img': regular json, 'ubj': universal binary json*/
     char faststep;               /**<1 use tMCimg-like approximated photon stepping (obsolete) */

--- a/src/mcxlab.cpp
+++ b/src/mcxlab.cpp
@@ -894,7 +894,7 @@ void mcx_set_field(const mxArray* root, const mxArray* item, int idx, Config* cf
         int len = mxGetNumberOfElements(item);
         const char* srctypeid[] = {"pencil", "isotropic", "cone", "gaussian", "planar",
                                    "pattern", "fourier", "arcsine", "disk", "fourierx", "fourierx2d", "zgaussian",
-                                   "line", "slit", "pencilarray", "pattern3d", "hyperboloid", "ring", ""
+                                   "line", "slit", "pencilarray", "pattern3d", "hyperboloid", "ring", "anglepattern", ""
                                   };
         char strtypestr[MAX_SESSION_LENGTH] = {'\0'};
 

--- a/src/pmcx.cpp
+++ b/src/pmcx.cpp
@@ -577,7 +577,7 @@ void parse_config(const py::dict& user_cfg, Config& mcx_config) {
         std::string src_type = py::str(user_cfg["srctype"]);
         const char* srctypeid[] = {"pencil", "isotropic", "cone", "gaussian", "planar",
                                    "pattern", "fourier", "arcsine", "disk", "fourierx", "fourierx2d", "zgaussian",
-                                   "line", "slit", "pencilarray", "pattern3d", "hyperboloid", "ring", ""
+                                   "line", "slit", "pencilarray", "pattern3d", "hyperboloid", "ring", "anglepattern", ""
                                   };
         char strtypestr[MAX_SESSION_LENGTH] = {'\0'};
 


### PR DESCRIPTION
Dear Dr. Fang
I'm following the PR in https://github.com/fangq/mcx/pull/98 from @kaoben2731.
I create a new source type ANGLEPATTERN which enable to use customize the source pattern.
For example in my case, 
The experiment source setting is like below:
![image](https://github.com/fangq/mcx/assets/82211039/309dbd8e-af4d-4ec0-b923-1d72f6ffeb04)

I used LED_source, which the Radiation Pattern is below,
![image](https://github.com/fangq/mcx/assets/82211039/fe5e3b2e-5628-4b8f-89c0-958fc4b372fd)

Then, I change it to the total power comes out from certain angle by multiple it by sin(angle)
![image](https://github.com/fangq/mcx/assets/82211039/3de656c5-db4e-475b-856d-54a3a1f8c260)

After that turn to the CDF
![image](https://github.com/fangq/mcx/assets/82211039/d9d271d8-8cd6-49a5-9804-7c860e2883bc)

In the end, we rand uniform(0,1) to sample the angles like below, (and **this array is the input pattern**)
![image](https://github.com/fangq/mcx/assets/82211039/8dc23ed1-4585-48e1-ac67-fe4f050ce766)


other parameters description,

```
srcparam1.x -> length of angle array: int,
if the source unit is rectangular:
srcparam1.y -> led_x 
srcparam1.z -> led_y
srcparam1.w -> 0
if the source unit is circle:
srcparam1.y -> 0 
srcparam1.z -> 0
srcparam1.w -> led_r

```

```
srcparam2 is about the radiated window size,
if the window is rectangular:
srcparam2.x -> win_x
srcparam2.y -> win_x
srcparam2.z -> 0
srcparam2.w -> led2win ( the distance between led to radiated window)
if the window is circle:
srcparam2.x -> 0
srcparam2.y -> 0
srcparam2.z -> win_r
srcparam2.w -> led2win ( the distance between led to radiated window)
```

```
srctype: MCX_SRC_ANGLEPATTERN
srcpattern: sampled angle array
srcparam1: {length of angle array (default=10000), 
            led_x, 
            led_y, 
            led_r}
srcparam2: {win_x, 
            win_y, 
            win_r, 
            led2win}
```
Result of rect source, circle radiated window:
![image](https://github.com/fangq/mcx/assets/82211039/65db5d39-384f-40a4-bb8c-73bfb2a49ccd)

Result of rect source, rect radiated window:
![image](https://github.com/fangq/mcx/assets/82211039/8a7f424b-9cde-41ac-b160-1314b0d5e0a7)


The attachment is the command and configuration to reproduce the result (rect source, circle radiated window)
[used_command.txt](https://github.com/fangq/mcx/files/13205965/used_command.txt)
[input_test.json](https://github.com/fangq/mcx/files/13205968/input_test.json)
