### PR TITLE
Fix wrong source type not raise

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -3,7 +3,7 @@
 Major updates are marked with a "*"
 
 == MCX v2025.9 (Kilo-Kelvin - 2.8), FangQ <q.fang (a) neu.edu> ==
-
+ 2025-09-25 [e230514] [bug] when srctype is unknown, the program can run successfully
  2025-08-26 [84adbfc] [pmcx] bump version to 0.5.1, some fixes after new unit tests
  2025-08-26 [e12bbef]*[pmcx] add additional unit tests
  2025-08-25 [521fcf0] [pmcx] pmcx v0.5.0

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ This release also contains a few bug fixes, including
 
 The detailed updates can be found in the below change log
 
+* 2025-09-25 [e230514] [bug] when srctype is unknown, the program can run successfully
 * 2025-08-26 [84adbfc] [pmcx] bump version to 0.5.1, some fixes after new unit tests
 * 2025-08-26 [e12bbef]*[pmcx] add additional unit tests
 * 2025-08-25 [521fcf0] [pmcx] pmcx v0.5.0

--- a/src/mcx_core.cu
+++ b/src/mcx_core.cu
@@ -3218,6 +3218,12 @@ void mcx_run_simulation(Config* cfg, GPUInfo* gpu) {
         MCX_FPRINTF(cfg->flog, "- %s: [Vanilla MCX] %s [%d.%d] for CUDA-arch [%d] on [%s]\n",
                     T_("code name"), T_("compiled by nvcc"), __CUDACC_VER_MAJOR__, __CUDACC_VER_MINOR__, __CUDA_ARCH_LIST__, __DATE__);
 #endif
+
+        // Validate source type
+        if (cfg->srctype == -1) {
+            MCX_ERROR(-1, "the specified source type is not supported");
+        }
+
         MCX_FPRINTF(cfg->flog, "- %s: RNG [%s] %s [%d]\n", T_("compiled with"), MCX_RNG_NAME, T_("seed length"), (int)((sizeof(RandType)*RAND_BUF_LEN) >> 2));
         fflush(cfg->flog);
     }

--- a/test/testmcx.sh
+++ b/test/testmcx.sh
@@ -101,6 +101,13 @@ echo "test pencil array source ... "
 temp=`"$MCX" --bench cube60planar --json '{"Optode":{"Source":{"Type":"pencilarray","Param1":[40,0,0,4],"Param2":[0,20,0,2]}}}' -d 0 -S 0 $PARAM | grep -o -E 'absorbed:.*23\.[0-9]+%'`
 if [ -z "$temp" ]; then echo "fail to run pencil array source"; fail=$((fail+1)); else echo "ok"; fi
 
+temp=`"$MCX" -Q cube60b -n 1e7 -W 10,10,10 -j '{"Optode":{"Source":{"Type":"unknown"}}}' $PARAM 2>&1`
+if [ ! -z "$temp" ]; then
+    echo "test unknown source type error handling ... "
+    haserror=`echo $temp | grep -o -E 'MCX[A-Z]* ERROR.-.*the specified source type is not supported'`
+    if [ -z "$haserror" ]; then echo "fail to catch unknown source type - should return error"; fail=$((fail+1)); else echo "ok"; fi
+fi
+
 echo "test boundary detector flags ... "
 temp=`"$MCX" --bench cube60 --bc '______111111' $PARAM -n 1e4 | grep -o -E 'detected.*[0-9.]+ photons' | grep -o -E '[0-9.]+ photon' | grep -o -E '9[7-9][0-9.]+'`
 if [ -z "$temp" ]; then echo "fail to detect photons in the cube60b benchmark"; fail=$((fail+1)); else echo "ok"; fi


### PR DESCRIPTION
## Check List
Before you submit your pull-request, please verify and check all below items

- [x] You have only modified the minimum number of lines that are necessary for the update; you should never add/remove white spaces to other lines that are irrelevant to the desired change.
- [x] You have run `make pretty` (requires `astyle` in the command line) under the `src/` folder and formatted your C/C++/CUDA source codes **before every commit**; similarly, you should run `python3 -m black *.py` (`pip install black` first) to reformat all modified Python codes, or run `mh_style --fix .` (`pip install miss-hit` first) at the top-folder to format all MATLAB scripts.
- [x] Add sufficient in-code comments following the [`doxygen` C format](https://fnch.users.sourceforge.net/doxygen_c.html)
- [x] In addition to source code changes, you should also update the documentation ([README.md](https://github.com/fangq/mcx/blob/master/README.md), [mcx_utils.c](https://github.com/fangq/mcx/blob/v2023/src/mcx_utils.c#L5029-L5236) and/or [mcxlab.m](https://github.com/fangq/mcx/blob/v2023/mcxlab/mcxlab.m)) if any command line flag was added or changed.

If your commits included in this PR contain changes that did not follow the above guidelines, you are strongly recommended to create a clean patch using `git rebase` and `git cherry-pick` to prevent in-compliant history from appearing in the upstream code.

Moreover, you are highly recommended to 

- Add a test in the `mcx/test/testmcx.sh` script, following existing examples, to test the newly added feature; or add a MATLAB script under `mcxlab/examples` to gives examples of the desired outputs
- MCX's simulation speed is currently limited by the number of GPU registers. In your change, please consider minimizing the use of registers by reusing existing ones. CUDA compilers may not be able to optimize register counts, thus require manual optimization.
- Please create a github Issue first with detailed descriptions of the problem, testing script and proposed fixes, and link the issue with this pull-request

## Please copy/paste the corresponding Issue's URL after the below dash

- https://github.com/fangq/mcx/issues/248

## Change Summary
Bug fix for source type validation:

* Added a check in `mcx_core.cu` to return an error if `cfg->srctype` is unknown, preventing the simulation from running with unsupported source types.

Testing improvements:

* Added a test in `testmcx.sh` to verify that specifying an unknown source type triggers the correct error message.

Documentation updates:

* Updated `ChangeLog.txt` and `README.md` to document the bug fix for handling unknown source types.