### PR TITLE
divide by actual mus in otRFmus/otWP/otWPTOF in SVMC replay, fix chain rule for mus/musp Jacobians in adjoint mode

### DIFF
--- a/src/mcx_core.cu
+++ b/src/mcx_core.cu
@@ -2250,13 +2250,16 @@ __global__ void mcx_main_loop(uint media[], OutputType field[], float genergy[],
 
                     theta = replayweight[photonidx];
 
-                    if (gcfg->outputtype == otRFmus || gcfg->outputtype == otWP) {
+                    if (gcfg->outputtype == otRFmus || gcfg->outputtype == otWP || gcfg->outputtype == otWPTOF) {
                         if (issvmc) {
-                            theta = (prop.mus == 0.f) ? 1.f : __fdividef(theta, prop.mus);
+                            theta = (prop.mus == 0.f) ? 0.f : __fdividef(cfg->unitinmm * theta, prop.mus);
                         }
 
                         if (gcfg->outputtype == otWP) {
                             tmp0 = theta;
+                        } else if (gcfg->outputtype == otWPTOF) {
+                            tmp0 = photontof[photonidx];
+                            tmp0 *= theta;   
                         } else {
                             ctheta = ppath[gcfg->w0offset + gcfg->srcnum];
                             stheta = ppath[gcfg->w0offset + gcfg->srcnum + 1];
@@ -2266,7 +2269,6 @@ __global__ void mcx_main_loop(uint media[], OutputType field[], float genergy[],
                         }
                     } else {
                         tmp0 = (gcfg->outputtype == otDCS) ? (1.f - ctheta) : 1.f;
-                        tmp0 = (gcfg->outputtype == otWPTOF) ? photontof[photonidx] : tmp0;
                         tmp0 *= theta;
                     }
 
@@ -4382,8 +4384,8 @@ void mcx_run_simulation(Config* cfg, GPUInfo* gpu) {
                             float onemg = 1.f - cfg->prop[medid].g;
 
                             if (mus > 0.f && onemg > 0.f) {
-                                /** adjoint_musp: J_D * 3*D^2 = J_D / (3*(1-g)^2*mus^2) */
-                                opscale = 1.f / (3.f * onemg * onemg * mus * mus);
+                                /** adjoint_musp: J_D * (-3*D^2) = -J_D / (3*(1-g)^2*mus^2) */
+                                opscale = -1.f / (3.f * onemg * onemg * mus * mus);
                             }
                         }
 
@@ -4448,11 +4450,11 @@ void mcx_run_simulation(Config* cfg, GPUInfo* gpu) {
                             float onemg = 1.f - cfg->prop[medid].g;
 
                             if (mus > 0.f && onemg > 0.f) {
-                                /** D = 1/(3*(1-g)*mus).  adjoint_mus:  J * 3*D^2*(1-g) = J / (3*(1-g)*mus^2)
-                                 *                         adjoint_musp: J * 3*D^2        = J / (3*(1-g)^2*mus^2) */
+                                /** D = 1/(3*(1-g)*mus).  adjoint_mus:  J * (-3*D^2*(1-g)) = - J / (3*(1-g)*mus^2)
+                                 *                         adjoint_musp: J * (-3*D^2)        = - J / (3*(1-g)^2*mus^2) */
                                 opscale = (cfg->outputtype == otAdjointMus)
-                                          ? 1.f / (3.f * onemg * mus * mus)
-                                          : 1.f / (3.f * onemg * onemg * mus * mus);
+                                          ? -1.f / (3.f * onemg * mus * mus)
+                                          : -1.f / (3.f * onemg * onemg * mus * mus);
                             }
                         }
 


### PR DESCRIPTION
**1.** Update the code to divide "b"/"wptof" (otWPTOF) counts also with the current scattering coefficient in SVMC mode during ray-tracing in replay. Set weight to zero if mus=0, since scattering events shouldn't happen in theory (and I got one very high value on boundary, which might result from this). Fix the scattering coefficient to be the true physical scattering coefficient for the division, if cfg.unitinmm is not 1 and mus has been scaled previously (cfg->prop[i].mus *= cfg->unitinmm). 

**NOTE**: Currently source code compilation fails since cfg->unitinmm is undefined on line 2255 in mcx_core.cu, where mus-division is performed. I did not find where the unitinmm is stored – gcfg does not have the field – can you help me? Otherwise compilation is successful. 

The below figure shows that the voxel-based (A correct, B modified) and SVMC (C; 0.5 shift not fixed yet) "scattering Jacobians" only match if we multiply the voxel-wise scattering coefficients with cfg.unitinmm=0.5 (mus/2, B) before scaling (post-processing in MCX; same optical parameters used in both simulations): 

<img width="5401" height="760" alt="Debug_SVMC_Replay_WithShift_Det3_PH" src="https://github.com/user-attachments/assets/dc302585-4863-4b38-bb32-302e6c90873b" />

 \
**2.** Fix the inner derivative sign when converting derivatives with respect to the diffusion coefficient (D) to derivatives with respect to the scattering coefficient (mus or musp) using the chain rule in the adjoint mode, since:

dA/dmus = dA/dD * dD/dmus = J_D * ( **-** 1/(3*(1-g)*mus^2))

In my simulations with demo_mcx_adjoint_jacobian.m, this fix matched the signs of the adjoint and replay scattering Jacobians (dXdmus and dYdmus; should match up to a constant scaling factor depending on measurement type), as shown in the figure below (modified source code used):

<img width="941" height="433" alt="Adjoint_dXYdmus_sign_PH" src="https://github.com/user-attachments/assets/75baf265-0616-4906-a502-3a7f1aa144f3" />

## Check List
Before you submit your pull-request, please verify and check all below items

- [x] You have only modified the minimum number of lines that are necessary for the update; you should never add/remove white spaces to other lines that are irrelevant to the desired change.
- [ ] You have run `make pretty` (requires `astyle` in the command line) under the `src/` folder and formatted your C/C++/CUDA source codes **before every commit**; similarly, you should run `python3 -m black *.py` (`pip install black` first) to reformat all modified Python codes, or run `mh_style --fix .` (`pip install miss-hit` first) at the top-folder to format all MATLAB scripts.
- [x] Add sufficient in-code comments following the [`doxygen` C format](https://fnch.users.sourceforge.net/doxygen_c.html)
- [ ] In addition to source code changes, you should also update the documentation ([README.md](https://github.com/fangq/mcx/blob/master/README.md), [mcx_utils.c](https://github.com/fangq/mcx/blob/v2023/src/mcx_utils.c#L5029-L5236) and/or [mcxlab.m](https://github.com/fangq/mcx/blob/v2023/mcxlab/mcxlab.m)) if any command line flag was added or changed.

If your commits included in this PR contain changes that did not follow the above guidelines, you are strongly recommended to create a clean patch using `git rebase` and `git cherry-pick` to prevent in-compliant history from appearing in the upstream code.

Moreover, you are highly recommended to 

- Add a test in the `mcx/test/testmcx.sh` script, following existing examples, to test the newly added feature; or add a MATLAB script under `mcxlab/examples` to gives examples of the desired outputs
- MCX's simulation speed is currently limited by the number of GPU registers. In your change, please consider minimizing the use of registers by reusing existing ones. CUDA compilers may not be able to optimize register counts, thus require manual optimization.
- Please create a github Issue first with detailed descriptions of the problem, testing script and proposed fixes, and link the issue with this pull-request

## Please copy/paste the corresponding Issue's URL after the below dash

- 
