### PR TITLE
Add AMD GPU support via HIP/ROCm

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,12 @@ modern graphics processing unit (GPU), this program is able to perform Monte
 Carlo (MC) simulations at a blazing speed, typically hundreds to
 a thousand times faster than a single-threaded CPU-based MC implementation.
 
-MCX is written in C and NVIDIA CUDA. It only be executed on NVIDIA GPUs.
-If you want to run hardware-accelerated MCX simulations on AMD/Intel GPUs
-or CPUs, please download MCX-CL (MCX for OpenCL), which is written in OpenCL.
-MCX and MCX-CL are highly compatible.
+MCX is written in C and NVIDIA CUDA, and runs on NVIDIA GPUs. The same CUDA
+source can also be compiled for AMD GPUs through HIP/ROCm by configuring with
+`-DUSE_HIP=ON` (see Requirement and Installation below). If you want to run
+hardware-accelerated MCX simulations on Intel GPUs or CPUs, please download
+MCX-CL (MCX for OpenCL), which is written in OpenCL. MCX and MCX-CL are highly
+compatible.
 
 Due to the nature of the underlying MC algorithms, MCX and MCX-CL are
 ray-tracing/ray-casting software under-the-hood. Compared to commonly
@@ -222,6 +224,24 @@ For MCX-CUDA, the requirements for using this software include
 
 -   a CUDA capable NVIDIA graphics card
 -   pre-installed NVIDIA graphics driver
+
+MCX can also be built for AMD GPUs using HIP/ROCm. In that case the
+requirements are
+
+-   a ROCm capable AMD graphics card
+-   a pre-installed AMD ROCm toolkit (including HIP)
+
+To compile the AMD build from source, configure the CMake project with HIP
+enabled and select the target GPU architecture, for example
+
+```
+cmake -S src -B build -DUSE_HIP=ON -DCMAKE_HIP_ARCHITECTURES=gfx90a
+cmake --build build
+```
+
+`CMAKE_HIP_ARCHITECTURES` accepts any ROCm GPU target (for example `gfx90a`
+or `gfx1100`); if omitted it defaults to `gfx90a`. The default NVIDIA build
+(`USE_HIP=OFF`) is unchanged.
 
 You must make sure that your NVIDIA graphics driver was installed properly.
 A list of CUDA capable cards can be found at [2]. The oldest 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,17 +15,52 @@ cmake_minimum_required(VERSION 3.5)
 
 project(mcx)
 
-find_package(CUDA QUIET REQUIRED)
+option(USE_HIP "Build with HIP for AMD GPUs" OFF)
+option(BUILD_MEX "Build mex" ON)
+
+# GPU sources that will be compiled with CUDA or HIP
+set(MCX_GPU_SOURCES mcx_core.cu)
+
+# Common sources (C/C++)
+set(MCX_COMMON_SOURCES
+    mcx_utils.c
+    mcx_shapes.c
+    mcx_bench.c
+    mcx_lang.c
+    mcx_mie.cpp
+    mcx_tictoc.c
+    mcx_neurojson.cpp
+    cjson/cJSON.c
+    ubj/ubjw.c
+)
+
+if(USE_HIP)
+    cmake_minimum_required(VERSION 3.21)
+    enable_language(HIP)
+    if(NOT DEFINED CMAKE_HIP_ARCHITECTURES OR CMAKE_HIP_ARCHITECTURES STREQUAL "")
+        set(CMAKE_HIP_ARCHITECTURES "gfx90a")
+    endif()
+    find_package(hip REQUIRED)
+
+    # Mark .cu files as HIP language
+    set_source_files_properties(${MCX_GPU_SOURCES} PROPERTIES LANGUAGE HIP)
+
+    # HIP compile flags for .cu files
+    set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} -DUSE_HIP -DUSE_ATOMIC -DSAVE_DETECTORS")
+
+    # Add USE_HIP define to C and C++ files as well (for header guards)
+    add_compile_definitions(USE_HIP)
+else()
+    find_package(CUDA QUIET REQUIRED)
+endif()
 
 find_package(OpenMP REQUIRED)
 
 add_subdirectory(zmat)
 
-option(BUILD_MEX "Build mex" ON)
-
 if(BUILD_PYTHON)
     add_subdirectory(pybind11)
-    find_package (Python3 COMPONENTS Interpreter Development)
+    find_package(Python3 COMPONENTS Interpreter Development)
     include_directories(${PYTHON_INCLUDE_DIRS})
 endif()
 
@@ -33,23 +68,15 @@ if(BUILD_MEX)
     find_package(Matlab)
 endif()
 
-string(REGEX REPLACE "[ \t\r\n]+" " -Xcompiler " OMPFLAG ${OpenMP_CXX_FLAGS})
-string(PREPEND OMPFLAG "-Xcompiler ")
-
-# NVCC Options
-set(
-    CUDA_NVCC_FLAGS
-    ${CUDA_NVCC_FLAGS};
-    -g -lineinfo -Xcompiler -Wall -Xcompiler -O3 -arch=sm_50
-    -DMCX_TARGET_NAME="Fermi MCX" -DUSE_ATOMIC -use_fast_math
-    -DSAVE_DETECTORS -Xcompiler -fPIC ${OMPFLAG}
-    )
-
 # C Options
-set(CMAKE_C_FLAGS "-g -Wall -std=c99 -fPIC")
+if(WIN32)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -std=c99 -DWIN32")
+else()
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -std=c99 -fPIC")
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/../bin)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/../lib)
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Add include directories
 include_directories(cjson ubj zmat zmat/easylzma zmat/easylzma/lzma)
@@ -57,119 +84,151 @@ include_directories(cjson ubj zmat zmat/easylzma zmat/easylzma/lzma)
 # Add link directories
 link_directories(zmat)
 
-# Create mcx library
-cuda_add_library(mcx STATIC
-    mcx_core.cu
-    mcx_core.h
-    mcx_utils.c
-    mcx_utils.h
-    mcx_shapes.c
-    mcx_shapes.h
-    mcx_bench.c
-    mcx_bench.h
-    mcx_lang.c
-    mcx_lang.h
-    mcx_mie.cpp
-    mcx_mie.h
-    mcx_tictoc.c
-    mcx_tictoc.h
-    mcx_neurojson.cpp
-    mcx_neurojson.h
-    cjson/cJSON.c
-    cjson/cJSON.h
-    ubj/ubj.h
-    ubj/ubjw.c
-    )
+if(USE_HIP)
+    # Create GPU object library (HIP sources only)
+    add_library(mcx_gpu OBJECT ${MCX_GPU_SOURCES})
+    target_link_libraries(mcx_gpu hip::device)
+    set_target_properties(mcx_gpu PROPERTIES HIP_ARCHITECTURES "${CMAKE_HIP_ARCHITECTURES}")
 
-# Add all project units
-cuda_add_executable(
-    mcx-exe
-    mcx.c
-    )
+    # Create mcx library (combine GPU objects with C/C++ sources)
+    add_library(mcx STATIC ${MCX_COMMON_SOURCES} $<TARGET_OBJECTS:mcx_gpu>)
+    target_link_libraries(mcx hip::host)
 
-set_target_properties(mcx-exe
-        PROPERTIES OUTPUT_NAME mcx)
+    # Create mcx executable
+    add_executable(mcx-exe mcx.c)
+    set_target_properties(mcx-exe PROPERTIES OUTPUT_NAME mcx)
+    # On Windows, MSVC-style linkers generate a .lib import stub for the exe
+    # with the same name as the static mcx library; redirect the exe's implib
+    # to a different path to avoid overwriting the static lib at link time.
+    if(WIN32)
+        set_target_properties(mcx-exe PROPERTIES
+            ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/implibs")
+    endif()
+    target_link_libraries(mcx-exe mcx OpenMP::OpenMP_CXX zmat)
 
-# Link options
-target_link_libraries(
-    mcx-exe
-    mcx OpenMP::OpenMP_CXX
-    zmat
-    )
+    if(BUILD_PYTHON)
+        add_library(_pmcx MODULE ${MCX_COMMON_SOURCES} $<TARGET_OBJECTS:mcx_gpu> pmcx.cpp)
+        target_compile_definitions(_pmcx PUBLIC MCX_CONTAINER PYBIND11_VERSION_MAJOR)
+        target_link_libraries(_pmcx hip::host OpenMP::OpenMP_CXX pybind11::module pybind11::lto pybind11::windows_extras zmat)
+        pybind11_extension(_pmcx)
+        pybind11_strip(_pmcx)
+        set_target_properties(_pmcx PROPERTIES CXX_VISIBILITY_PRESET "hidden")
+    endif()
 
-if (BUILD_PYTHON)
-    cuda_add_library(_pmcx MODULE
-            mcx_core.cu
-            mcx_core.h
-            mcx_utils.c
-            mcx_utils.h
-            mcx_shapes.c
-            mcx_shapes.h
-            mcx_bench.c
-            mcx_bench.h
-            mcx_lang.c
-            mcx_lang.h
-            mcx_mie.cpp
-            mcx_mie.h
-            mcx_tictoc.c
-            mcx_tictoc.h
-            cjson/cJSON.c
-            cjson/cJSON.h
-            pmcx.cpp
-            )
-    target_compile_definitions(_pmcx PUBLIC MCX_CONTAINER PYBIND11_VERSION_MAJOR)
+    if(BUILD_MEX AND Matlab_FOUND)
+        add_library(mcx-matlab STATIC ${MCX_COMMON_SOURCES} $<TARGET_OBJECTS:mcx_gpu>)
+        target_compile_definitions(mcx-matlab PUBLIC MCX_CONTAINER MATLAB_MEX_FILE)
+        target_link_libraries(mcx-matlab hip::host)
 
-    target_link_libraries(_pmcx OpenMP::OpenMP_CXX pybind11::module pybind11::lto pybind11::windows_extras zmat)
-
-    pybind11_extension(_pmcx)
-    pybind11_strip(_pmcx)
-
-    set_target_properties(_pmcx PROPERTIES CXX_VISIBILITY_PRESET "hidden"
-            CUDA_VISIBILITY_PRESET "hidden")
-endif()
-
-# Build mex file
-if(BUILD_MEX AND Matlab_FOUND)
-    # Create mcx-matlab library
-    cuda_add_library(mcx-matlab STATIC
-            mcx_core.cu
-            mcx_core.h
-            mcx_utils.c
-            mcx_utils.h
-            mcx_shapes.c
-            mcx_shapes.h
-            mcx_bench.c
-            mcx_bench.h
-            mcx_lang.c
-            mcx_lang.h
-            mcx_mie.cpp
-            mcx_mie.h
-            mcx_tictoc.c
-            mcx_tictoc.h
-            cjson/cJSON.c
-            cjson/cJSON.h
-            )
-
-    target_compile_definitions(mcx-matlab PUBLIC MCX_CONTAINER MATLAB_MEX_FILE)
-
-    if(${CMAKE_VERSION} VERSION_LESS "3.24.0")
+        if(${CMAKE_VERSION} VERSION_LESS "3.24.0")
             matlab_add_mex(
               NAME mcxlab
               SRC mcxlab.cpp
               LINK_TO OpenMP::OpenMP_CXX mcx-matlab
             )
-    else()
+        else()
             matlab_add_mex(
               NAME mcxlab
               SRC mcxlab.cpp
               NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES
               LINK_TO ${Matlab_MEX_LIBRARY} ${Matlab_MX_LIBRARY} OpenMP::OpenMP_CXX mcx-matlab
             )
+        endif()
+
+        target_compile_definitions(mcxlab PUBLIC MCX_CONTAINER MATLAB_MEX_FILE)
+        set_target_properties(mcxlab PROPERTIES OUTPUT_NAME ${CMAKE_SOURCE_DIR}/../mcxlab/mcx)
+    endif()
+else()
+    # Original CUDA build using legacy FindCUDA
+    string(REGEX REPLACE "[ \t\r\n]+" " -Xcompiler " OMPFLAG ${OpenMP_CXX_FLAGS})
+    string(PREPEND OMPFLAG "-Xcompiler ")
+
+    set(
+        CUDA_NVCC_FLAGS
+        ${CUDA_NVCC_FLAGS};
+        -g -lineinfo -Xcompiler -Wall -Xcompiler -O3 -arch=sm_50
+        -DMCX_TARGET_NAME="Fermi MCX" -DUSE_ATOMIC -use_fast_math
+        -DSAVE_DETECTORS -Xcompiler -fPIC ${OMPFLAG}
+    )
+
+    # Create mcx library
+    cuda_add_library(mcx STATIC
+        ${MCX_GPU_SOURCES}
+        mcx_core.h
+        ${MCX_COMMON_SOURCES}
+        mcx_utils.h
+        mcx_shapes.h
+        mcx_bench.h
+        mcx_lang.h
+        mcx_mie.h
+        mcx_tictoc.h
+        mcx_neurojson.h
+        cjson/cJSON.h
+        ubj/ubj.h
+    )
+
+    # Add all project units
+    cuda_add_executable(mcx-exe mcx.c)
+
+    set_target_properties(mcx-exe PROPERTIES OUTPUT_NAME mcx)
+
+    # Link options
+    target_link_libraries(mcx-exe mcx OpenMP::OpenMP_CXX zmat)
+
+    if(BUILD_PYTHON)
+        cuda_add_library(_pmcx MODULE
+            ${MCX_GPU_SOURCES}
+            mcx_core.h
+            ${MCX_COMMON_SOURCES}
+            mcx_utils.h
+            mcx_shapes.h
+            mcx_bench.h
+            mcx_lang.h
+            mcx_mie.h
+            mcx_tictoc.h
+            cjson/cJSON.h
+            pmcx.cpp
+        )
+        target_compile_definitions(_pmcx PUBLIC MCX_CONTAINER PYBIND11_VERSION_MAJOR)
+        target_link_libraries(_pmcx OpenMP::OpenMP_CXX pybind11::module pybind11::lto pybind11::windows_extras zmat)
+        pybind11_extension(_pmcx)
+        pybind11_strip(_pmcx)
+        set_target_properties(_pmcx PROPERTIES CXX_VISIBILITY_PRESET "hidden" CUDA_VISIBILITY_PRESET "hidden")
     endif()
 
+    # Build mex file
+    if(BUILD_MEX AND Matlab_FOUND)
+        cuda_add_library(mcx-matlab STATIC
+            ${MCX_GPU_SOURCES}
+            mcx_core.h
+            ${MCX_COMMON_SOURCES}
+            mcx_utils.h
+            mcx_shapes.h
+            mcx_bench.h
+            mcx_lang.h
+            mcx_mie.h
+            mcx_tictoc.h
+            cjson/cJSON.h
+        )
 
-    target_compile_definitions(mcxlab PUBLIC MCX_CONTAINER MATLAB_MEX_FILE)
+        target_compile_definitions(mcx-matlab PUBLIC MCX_CONTAINER MATLAB_MEX_FILE)
 
-    set_target_properties(mcxlab
-            PROPERTIES OUTPUT_NAME ${CMAKE_SOURCE_DIR}/../mcxlab/mcx)
+        if(${CMAKE_VERSION} VERSION_LESS "3.24.0")
+            matlab_add_mex(
+              NAME mcxlab
+              SRC mcxlab.cpp
+              LINK_TO OpenMP::OpenMP_CXX mcx-matlab
+            )
+        else()
+            matlab_add_mex(
+              NAME mcxlab
+              SRC mcxlab.cpp
+              NO_IMPLICIT_LINK_TO_MATLAB_LIBRARIES
+              LINK_TO ${Matlab_MEX_LIBRARY} ${Matlab_MX_LIBRARY} OpenMP::OpenMP_CXX mcx-matlab
+            )
+        endif()
+
+        target_compile_definitions(mcxlab PUBLIC MCX_CONTAINER MATLAB_MEX_FILE)
+        set_target_properties(mcxlab PROPERTIES OUTPUT_NAME ${CMAKE_SOURCE_DIR}/../mcxlab/mcx)
+    endif()
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,8 +45,12 @@ if(USE_HIP)
     # Mark .cu files as HIP language
     set_source_files_properties(${MCX_GPU_SOURCES} PROPERTIES LANGUAGE HIP)
 
-    # HIP compile flags for .cu files
-    set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} -DUSE_HIP -DUSE_ATOMIC -DSAVE_DETECTORS")
+    # HIP compile flags for .cu files.
+    # -munsafe-fp-atomics lets clang emit the native global_atomic_add_f32 on
+    # CDNA/RDNA instead of a compare-and-swap retry loop; the fluence grid is
+    # accumulated with float atomicAdd, so this is the dominant performance flag.
+    # -ffast-math is the HIP counterpart of the CUDA build's -use_fast_math.
+    set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} -DUSE_HIP -DUSE_ATOMIC -DSAVE_DETECTORS -munsafe-fp-atomics -ffast-math")
 
     # Add USE_HIP define to C and C++ files as well (for header guards)
     add_compile_definitions(USE_HIP)

--- a/src/cuda_to_hip.h
+++ b/src/cuda_to_hip.h
@@ -1,0 +1,84 @@
+/**
+ * @file cuda_to_hip.h
+ * @brief CUDA-to-HIP compatibility header for MCX
+ *
+ * @author Jeff Daily <jeff.daily@amd.com>
+ * @copyright Copyright (c) 2026 Advanced Micro Devices, Inc.
+ *
+ * On AMD/ROCm (USE_HIP defined), this header aliases CUDA runtime API calls
+ * to their HIP equivalents. On NVIDIA, it is a transparent passthrough to
+ * the CUDA runtime.
+ */
+
+#pragma once
+
+#if defined(USE_HIP) || defined(__HIP_PLATFORM_AMD__)
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// Runtime API
+#define cudaError_t                     hipError_t
+#define cudaSuccess                     hipSuccess
+#define cudaGetLastError                hipGetLastError
+#define cudaGetErrorString              hipGetErrorString
+
+// Device management
+#define cudaGetDeviceCount              hipGetDeviceCount
+#define cudaGetDeviceProperties         hipGetDeviceProperties
+#define cudaSetDevice                   hipSetDevice
+#define cudaDeviceSynchronize           hipDeviceSynchronize
+#define cudaDeviceProp                  hipDeviceProp_t
+
+// Memory management
+#define cudaMalloc                      hipMalloc
+#define cudaFree                        hipFree
+#define cudaMemcpy                      hipMemcpy
+#define cudaMemset                      hipMemset
+#define cudaMemcpyHostToDevice          hipMemcpyHostToDevice
+#define cudaMemcpyDeviceToHost          hipMemcpyDeviceToHost
+#define cudaMemcpyToSymbol              hipMemcpyToSymbol
+#define cudaMemcpyFromSymbol            hipMemcpyFromSymbol
+
+// Events
+#define cudaEvent_t                     hipEvent_t
+#define cudaEventCreate                 hipEventCreate
+#define cudaEventRecord                 hipEventRecord
+#define cudaEventQuery                  hipEventQuery
+#define cudaEventDestroy                hipEventDestroy
+
+// Device reset
+#define cudaDeviceReset                 hipDeviceReset
+
+// Host allocation
+#define cudaHostAlloc                   hipHostMalloc
+#define cudaFreeHost                    hipHostFree
+#define cudaHostAllocMapped             hipHostMallocMapped
+#define cudaHostAllocPortable           hipHostMallocPortable
+#define cudaHostGetDevicePointer        hipHostGetDevicePointer
+
+// Math intrinsics
+// umin/umax are CUDA device math functions; HIP uses min/max from std
+__device__ __forceinline__ unsigned int umin(unsigned int a, unsigned int b) { return min(a, b); }
+__device__ __forceinline__ unsigned int umax(unsigned int a, unsigned int b) { return max(a, b); }
+
+// exp10f is provided by HIP already
+
+// __int_as_float / __float_as_int are provided by HIP as-is
+
+// FP16: HIP provides __half, __half_raw, __half2float in hip/hip_fp16.h
+
+// CUDA version macros -- set to HIP/ROCm equivalent or safe values
+#include <hip/hip_version.h>
+#define __CUDACC_VER_MAJOR__            HIP_VERSION_MAJOR
+#define __CUDACC_VER_MINOR__            HIP_VERSION_MINOR
+#ifndef __CUDA_ARCH_LIST__
+#define __CUDA_ARCH_LIST__              0
+#endif
+
+#else
+
+#include <cuda_runtime.h>
+#include "cuda_fp16.h"
+
+#endif

--- a/src/mcx_core.cu
+++ b/src/mcx_core.cu
@@ -49,8 +49,11 @@ This unit is written with CUDA-C and shall be compiled using nvcc in cuda-toolki
 #include "mcx_tictoc.h"
 #include "mcx_const.h"
 
+#include "cuda_to_hip.h"
+
+#if !defined(USE_HIP) && !defined(__HIP_PLATFORM_AMD__)
 #include <cuda.h>
-#include "cuda_fp16.h"
+#endif
 
 #ifdef USE_DOUBLE
     typedef double OutputType;
@@ -97,6 +100,9 @@ This unit is written with CUDA-C and shall be compiled using nvcc in cuda-toolki
         #define __CUDA_ARCH_LIST__ 350
     #endif
 #endif
+
+// HIP provides float3 operators via HIP_vector_type; CUDA does not
+#if !defined(USE_HIP) && !defined(__HIP_PLATFORM_AMD__)
 
 /**
  * @brief Adding two float3 vectors c=a+b
@@ -156,6 +162,8 @@ __device__ float3 operator *(const float3& a, const float& b) {
 __device__ float3 operator *(const float3& a, const float3& b) {
     return make_float3(a.x * b.x, a.y * b.y, a.z * b.z);
 }
+
+#endif // !USE_HIP
 
 /**
  * @brief Dot-product of two float3 vectors c=a*b
@@ -2796,7 +2804,17 @@ __global__ void mcx_main_loop(uint media[], OutputType field[], float genergy[],
                         rv = float3(__fdividef(1.f, v.x), __fdividef(1.f, v.y), __fdividef(1.f, v.z));
                     } else { //< do reflection
                         GPUDEBUG(("ref faceid=%d p=[%f %f %f] v_old=[%f %f %f]\n", flipdir[3], p.x, p.y, p.z, v.x, v.y, v.z));
-                        (flipdir[3] == 0) ? (v.x = -v.x) : ((flipdir[3] == 1) ? (v.y = -v.y) : (v.z = -v.z)) ;
+                        /* Flip the velocity component normal to the reflecting face. The branchless
+                         * form is required for correctness on ROCm: at -O1 and above, the AMDGPU
+                         * backend miscompiles a runtime-branch-selected in-place float negation
+                         * (the equivalent ternary/if-else that negates only v.x, v.y, or v.z based
+                         * on flipdir[3]) and drops the negation, leaving the reflected photon
+                         * heading back out of the volume. That silently broke boundary reflection
+                         * (cube60b absorbed ~18% instead of ~27%). Multiplying every component by a
+                         * per-component sign compiles correctly and is arithmetically identical. */
+                        v.x *= (flipdir[3] == 0) ? -1.f : 1.f;
+                        v.y *= (flipdir[3] == 1) ? -1.f : 1.f;
+                        v.z *= (flipdir[3] == 2) ? -1.f : 1.f;
                         rv = float3(__fdividef(1.f, v.x), __fdividef(1.f, v.y), __fdividef(1.f, v.z));
                         (flipdir[3] == 0) ?
                         (p.x = mcx_nextafterf(__float2int_rn(p.x), (v.x > 0.f) - (v.x < 0.f))) :
@@ -3487,7 +3505,7 @@ void mcx_run_simulation(Config* cfg, GPUInfo* gpu) {
      * Allocate pinned memory variable, progress, for real-time update during kernel run-time
      */
     CUDA_ASSERT(cudaHostAlloc((void**)&progress, sizeof(int), cudaHostAllocMapped));
-    CUDA_ASSERT(cudaHostGetDevicePointer((int**)&gprogress, (int*)progress, 0));
+    CUDA_ASSERT(cudaHostGetDevicePointer((void**)&gprogress, (void*)progress, 0));
     *progress = 0;
 
     if (cfg->debuglevel & (MCX_DEBUG_MOVE | MCX_DEBUG_MOVE_ONLY)) {
@@ -3600,7 +3618,10 @@ void mcx_run_simulation(Config* cfg, GPUInfo* gpu) {
     if (cfg->printnum >= 0) {
         mcx_printheader(cfg);
 
-#ifdef MCX_TARGET_NAME
+#if defined(USE_HIP) || defined(__HIP_PLATFORM_AMD__)
+        MCX_FPRINTF(cfg->flog, "- %s: [AMD MCX] %s [%d.%d] on [%s]\n",
+                    T_("code name"), T_("compiled by hipcc"), HIP_VERSION_MAJOR, HIP_VERSION_MINOR, __DATE__);
+#elif defined(MCX_TARGET_NAME)
         MCX_FPRINTF(cfg->flog, "- %s: [%s] %s [%d.%d] for CUDA-arch [%d] on [%s]\n",
                     T_("code name"), MCX_TARGET_NAME, T_("compiled by nvcc"), __CUDACC_VER_MAJOR__, __CUDACC_VER_MINOR__, __CUDA_ARCH_LIST__, __DATE__);
 #else

--- a/src/mcx_mie.cpp
+++ b/src/mcx_mie.cpp
@@ -38,7 +38,7 @@
 #include "mcx_mie.h"
 #include "mcx_const.h"
 
-#include <vector_types.h>
+#include "mcx_vector_types.h"
 
 #if defined(_MSC_VER) || defined(__APPLE__)
     #include <complex>

--- a/src/mcx_shapes.h
+++ b/src/mcx_shapes.h
@@ -35,7 +35,7 @@
 #ifndef _MCEXTREME_RASTERIZER_H
 #define _MCEXTREME_RASTERIZER_H
 
-#include <vector_types.h>
+#include "mcx_vector_types.h"
 
 #ifdef  __cplusplus
 extern "C" {

--- a/src/mcx_tictoc.c
+++ b/src/mcx_tictoc.c
@@ -37,18 +37,28 @@
 #define _DEFAULT_SOURCE
 #define _BSD_SOURCE
 
-#ifndef USE_OS_TIMER          /**< use CUDA event for time estimation */
+#ifndef USE_OS_TIMER          /**< use CUDA/HIP event for time estimation */
+#if defined(USE_HIP) || defined(__HIP_PLATFORM_AMD__)
+#include <hip/hip_runtime.h>
+#define cudaEvent_t                     hipEvent_t
+#define cudaGetDevice                   hipGetDevice
+#define cudaEventRecord                 hipEventRecord
+#define cudaEventSynchronize            hipEventSynchronize
+#define cudaEventElapsedTime            hipEventElapsedTime
+#define cudaEventCreate                 hipEventCreate
+#else
 #include <cuda.h>
 #include <driver_types.h>
 #include <cuda_runtime_api.h>
+#endif
 #define MAX_DEVICE 256
 
 static cudaEvent_t timerStart[MAX_DEVICE], timerStop[MAX_DEVICE];
 
 /**
- * @brief CUDA timing function using cudaEventElapsedTime
+ * @brief CUDA/HIP timing function using cudaEventElapsedTime
  *
- * Use CUDA events to query elapsed time in ms between two events
+ * Use CUDA/HIP events to query elapsed time in ms between two events
  */
 
 unsigned int GetTimeMillis () {
@@ -62,7 +72,7 @@ unsigned int GetTimeMillis () {
 }
 
 /**
- * @brief Start CUDA timer
+ * @brief Start CUDA/HIP timer
  */
 
 unsigned int StartTimer () {

--- a/src/mcx_utils.c
+++ b/src/mcx_utils.c
@@ -45,6 +45,10 @@
 #endif
 #include <sys/types.h>
 #include <sys/stat.h>
+#ifdef WIN32
+    #include <direct.h>
+    #define mkdir(path, mode) _mkdir(path)
+#endif
 #include "mcx_utils.h"
 #include "mcx_const.h"
 #include "mcx_shapes.h"
@@ -4178,7 +4182,7 @@ void mcx_loadseedjdat(char* filename, Config* cfg) {
     char* jbuf;
     int len;
 
-    FILE* fp = fopen(filename, "rt");
+    FILE* fp = fopen(filename, "rb");
 
     if (fp == NULL) {
         MCX_ERROR(-6, "fail to open the specified seed jdata file");

--- a/src/mcx_utils.h
+++ b/src/mcx_utils.h
@@ -36,7 +36,7 @@
 #define _MCEXTREME_UTILITIES_H
 
 #include <stdio.h>
-#include <vector_types.h>
+#include "mcx_vector_types.h"
 #include "cjson/cJSON.h"
 #include "float.h"
 #include "nifti1.h"

--- a/src/mcx_vector_types.h
+++ b/src/mcx_vector_types.h
@@ -1,0 +1,64 @@
+/**
+ * @file mcx_vector_types.h
+ * @brief Vector type definitions for MCX
+ *
+ * @author Jeff Daily <jeff.daily@amd.com>
+ * @copyright Copyright (c) 2026 Advanced Micro Devices, Inc.
+ *
+ * Provides float3, float4, uint3, uint4, int3, int4 types that are compatible
+ * with both CUDA vector_types.h and HIP hip_vector_types.h.
+ *
+ * For C code compiled with gcc/clang (not hipcc), we define the types ourselves.
+ * For CUDA (.cu) and HIP (.cu compiled as HIP), we use the native headers.
+ */
+
+#ifndef _MCX_VECTOR_TYPES_H
+#define _MCX_VECTOR_TYPES_H
+
+#if defined(__HIPCC__) || defined(__HIP__)
+/* Compiled with hipcc -- include HIP runtime (provides __align__ and vector types) */
+#include <hip/hip_runtime.h>
+
+#elif defined(__CUDACC__)
+/* Compiled with nvcc -- use CUDA vector types */
+#include <vector_types.h>
+
+#elif defined(USE_HIP) || defined(__HIP_PLATFORM_AMD__)
+/* Plain C/C++ code for HIP build -- define types manually */
+
+/* Portable alignment macro for struct definitions */
+#if defined(__GNUC__) || defined(__clang__)
+#define __align__(n) __attribute__((aligned(n)))
+#elif defined(_MSC_VER)
+#define __align__(n) __declspec(align(n))
+#else
+#define __align__(n)
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Align float4/uint4/int4 to 16 bytes to match HIP vector types */
+typedef struct { float x, y, z; } float3;
+typedef struct __align__(16) { float x, y, z, w; } float4;
+typedef struct { unsigned int x, y, z; } uint3;
+typedef struct __align__(16) { unsigned int x, y, z, w; } uint4;
+typedef struct { int x, y, z; } int3;
+typedef struct __align__(16) { int x, y, z, w; } int4;
+typedef struct { int x, y; } int2;
+typedef struct { unsigned int x, y; } uint2;
+typedef struct { float x, y; } float2;
+typedef struct { float x; } float1;
+
+#ifdef __cplusplus
+}
+#endif
+
+#else
+/* CUDA build -- use CUDA vector types */
+#include <vector_types.h>
+
+#endif
+
+#endif /* _MCX_VECTOR_TYPES_H */

--- a/src/zmat/CMakeLists.txt
+++ b/src/zmat/CMakeLists.txt
@@ -11,7 +11,11 @@ project(zmat)
 option(STATIC_LIB "Build static library" ON)
 
 # C Options
-set(CMAKE_C_FLAGS "-g -Wall -O3 -fPIC")
+if(WIN32)
+    set(CMAKE_C_FLAGS "-g -Wall -O3")
+else()
+    set(CMAKE_C_FLAGS "-g -Wall -O3 -fPIC")
+endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/../)
 
 # Add include directories


### PR DESCRIPTION
This PR adds AMD GPU support to MCX by allowing the existing CUDA source to be compiled for AMD GPUs through HIP/ROCm, while keeping the default NVIDIA CUDA build completely unchanged.

The CUDA runtime API calls used by MCX are mapped to their HIP equivalents through a thin compatibility header (`src/cuda_to_hip.h`). On an NVIDIA build this header is a transparent passthrough to the CUDA runtime, so the NVIDIA code path compiles and behaves exactly as before; on a ROCm build (`USE_HIP` defined) it aliases the `cuda*` runtime symbols to the corresponding `hip*` calls. A second header (`src/mcx_vector_types.h`) supplies the `float3`/`float4`/`uint3`/`uint4`/`int3`/`int4` vector types so the C, CUDA, and HIP translation units agree on layout and alignment regardless of which compiler (gcc/clang, nvcc, or hipcc) builds a given file.

The CMake build gains a `USE_HIP` option. When enabled it turns on the HIP language, compiles the `.cu` GPU sources with hipcc, links against `hip::device`/`hip::host`, and selects the target GPU architecture via `CMAKE_HIP_ARCHITECTURES`. When `USE_HIP` is off (the default) the build is the unmodified CUDA build.

Two small device-code corrections are included so the simulation produces correct results on AMD GPUs: a boundary-reflection expression that was being miscompiled on AMD targets is rewritten to an equivalent form, and the Windows build is fixed for the ROCm toolchain (`-fPIC`, the `WIN32` macro, an import-library conflict, and a binary `fread`). These do not change behavior on the NVIDIA path.

### How to build the ROCm version

Configure with HIP enabled and pick the target architecture:

```
cmake -S src -B build -DUSE_HIP=ON -DCMAKE_HIP_ARCHITECTURES=gfx90a
cmake --build build
```

`CMAKE_HIP_ARCHITECTURES` accepts any ROCm GPU target (for example `gfx90a` or `gfx1100`) and defaults to `gfx90a` if omitted. Building without `-DUSE_HIP=ON` produces the usual CUDA binary.

### Validation

The ROCm build was exercised on real AMD hardware end to end on Linux (CDNA2 gfx90a and RDNA3 gfx1100) and Windows (RDNA4 gfx1201), running MCX simulations and confirming the fluence and detected-photon outputs match the expected results. The default NVIDIA CUDA build is unchanged.
