### PR TITLE
[bug] Use GPUDEBUG macro instead of raw printf for kernel error message

### DIFF
--- a/src/mcx_core.cu
+++ b/src/mcx_core.cu
@@ -2859,7 +2859,7 @@ __global__ void mcx_main_loop(uint media[], OutputType field[], float genergy[],
         }
 
         if (mediaid == 0 || idx1d == OUTSIDE_VOLUME_MIN || idx1d == OUTSIDE_VOLUME_MAX) {
-            printf("ERROR: should never happen! mediaid=%d idx1d=%X isreflect=%d gcfg->doreflect=%d n1=%f n2=%f isdet=%d flipdir[3]=%d p=(%f %f %f)[%d %d %d]\n", mediaid, idx1d, isreflect, gcfg->doreflect, n1, prop.n, isdet, flipdir[3], p.x, p.y, p.z, flipdir[0], flipdir[1], flipdir[2]);
+            GPUDEBUG(("ERROR: should never happen! mediaid=%d idx1d=%X isreflect=%d gcfg->doreflect=%d n1=%f n2=%f isdet=%d flipdir[3]=%d p=(%f %f %f)[%d %d %d]\n", mediaid, idx1d, isreflect, gcfg->doreflect, n1, prop.n, isdet, flipdir[3], p.x, p.y, p.z, flipdir[0], flipdir[1], flipdir[2]));
             return;
         }
     }


### PR DESCRIPTION
The raw `printf` in the "should never happen" branch is compiled into the kernel even in release builds, increasing register pressure. Since MCX is register-limited, replacing it with GPUDEBUG (a no-op unless MCX_DEBUG is defined) frees registers and improves occupancy, giving ~2.5% speedup in release mode on AMD `gf90a`.