### PR TITLE
fix: correct dephotons to detphotons typo in pmcx/utils.py (closes #268)

### DIFF
--- a/pmcx/pmcx/utils.py
+++ b/pmcx/pmcx/utils.py
@@ -623,7 +623,7 @@ def mcxlab(*args):
 
         if "detphotons" in args[0] and isinstance(args[0]["detphotons"], dict):
             if "data" in args[0]["detphotons"]:
-                args[0]["detphotons"] = args[0]["dephotons"]["data"]
+                args[0]["detphotons"] = args[0]["detphotons"]["data"]
             else:
                 fulldetdata = ["detid", "nscat", "ppath", "mom", "p", "v", "w0"]
                 detfields = [x in args[0]["detphotons"] for x in fulldetdata]


### PR DESCRIPTION
## Summary
1-line fix correcting the typo `dephotons` → `detphotons` in `pmcx/pmcx/utils.py` line 626.

## Compliance
- GH007: This PR adheres to GitHub Flow — one feature branch per change.
- Swift syntax: N/A (Python codebase)
- All checks pass.

Closes #268